### PR TITLE
Fix NIP-11 request URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostrwatch-js",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "js library for aggregating data from and checking the status of nostr relays",
   "main": "index.js",
   "type": "module",

--- a/src/checker.js
+++ b/src/checker.js
@@ -100,7 +100,8 @@ RelayChecker.prototype.getInfo = async function(){
       this.log(`timeout`, `NIP-11 info document was not returned within 10000 milliseconds`) //need to add timeout opt for info.
       resolve( {} ) 
     }, 10*1000 )
-    const _res = await fetch(`https://${url.hostname}/`, { method: 'GET', headers: headers})
+    url.protocol = "https"
+    const _res = await fetch(url.toString(), { method: 'GET', headers: headers})
       .then(async response => { 
         try {
           let res = await response.json()


### PR DESCRIPTION
Legacy code was incorrect. Instead, changed protocol directly and then printed with `URL.toString`.

Reported [here](https://github.com/dskvr/nostr-watch/issues/645)